### PR TITLE
Add GH Action for Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Package & Storybook
 on:
   push:
     branches:
-      - main
+      - gh-workflow # temp to test
 
 jobs:
   publish_docker_image:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Package & Storybook
 on:
   push:
     branches:
-      - gh-workflow # temp to test
+      - main
 
 jobs:
   publish_docker_image:
@@ -20,7 +20,7 @@ jobs:
         run: yarn build && yarn build-storybook
 
       - name: Publish NPM Package
-        run: echo "yarn publish --non-interactive"
+        run: yarn publish --non-interactive
 
       - name: Update GH Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Latest
-        uses: yarn build && yarn build-storybook
+        run: yarn build && yarn build-storybook
 
       - name: Publish NPM Package
         run: yarn publish --non-interactive

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         run: yarn build && yarn build-storybook
 
       - name: Publish NPM Package
-        run: yarn publish --non-interactive
+        run: yarn publish --non-interactive --access public
 
       - name: Update GH Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build latest
+      - name: Build Latest
         uses: yarn build && yarn build-storybook
 
-      - name: Publish npm package
+      - name: Publish NPM Package
         run: yarn publish --non-interactive
 
       - name: Update GH Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Build Latest
         run: yarn build && yarn build-storybook
 
       - name: Publish NPM Package
-        run: yarn publish --non-interactive
+        run: echo "yarn publish --non-interactive"
 
       - name: Update GH Pages
         run: yarn deploy-storybook

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,7 @@ jobs:
         run: echo "yarn publish --non-interactive"
 
       - name: Update GH Pages
-        run: yarn deploy-storybook
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish Package & Storybook
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_docker_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build latest
+        uses: yarn build && yarn build-storybook
+
+      - name: Publish npm package
+        run: yarn publish --non-interactive
+
+      - name: Update GH Pages
+        run: yarn deploy-storybook

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1-beta.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Adds a `publish.yml` github action to automate publishing a new NPM package and updating the github pages with the latest code. 

Only happens when merging to `main`.