### PR TITLE
add-controlled-input-textarea

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -26,4 +26,9 @@ export const parameters = {
   docs: {
     theme: themes.dark,
   },
+  options: {
+    storySort: {
+      method: 'alphabetical',
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raidguild/design-system",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "license": "MIT",
   "author": "Raid Guild",
   "module": "dist/design-system.esm.js",

--- a/src/components/atoms/ControlledInput/ControlledInput.tsx
+++ b/src/components/atoms/ControlledInput/ControlledInput.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ChakraInput, ChakraInputProps, FormLabel } from '../../chakra';
+
+type CustomControlledInputProps = {
+  label?: string; // optional, displays label if provided
+  name?: string; // optional, not required since no form control
+  tip?: string; // optional, displays tip if provided
+  defaultValue?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+};
+
+type ControlledInputProps = ChakraInputProps & CustomControlledInputProps;
+
+const ControlledInput: React.FC<ControlledInputProps> = ({
+  label,
+  name,
+  defaultValue,
+  onChange,
+  value,
+  ...props
+}: ControlledInputProps) => {
+  return (
+    <>
+      {label && <FormLabel>{label}</FormLabel>}
+      <ChakraInput
+        name={name}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        value={value}
+        {...props} // catches other ChakraInput props such as placeholder
+      />
+    </>
+  );
+};
+
+export default ControlledInput;

--- a/src/components/atoms/ControlledInput/index.tsx
+++ b/src/components/atoms/ControlledInput/index.tsx
@@ -1,0 +1,1 @@
+export { default as ControlledInput } from './ControlledInput';

--- a/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
+++ b/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import {
+  ChakraTextarea,
+  ChakraTextareaProps,
+  FormControl,
+  FormLabel,
+} from '../../chakra';
+
+type CustomControlledTextareaProps = {
+  label: string;
+  name: string;
+  localForm: UseFormReturn;
+};
+
+type ControlledTextareaProps = ChakraTextareaProps &
+  CustomControlledTextareaProps;
+
+const ControlledTextarea: React.FC<ControlledTextareaProps> = ({
+  label,
+  name,
+  localForm,
+  ...props
+}: ControlledTextareaProps) => {
+  const { register } = localForm;
+
+  return (
+    <FormControl>
+      {label && <FormLabel>{label}</FormLabel>}
+      {/* @ts-ignore next-line */}
+      <ChakraTextarea {...props} {...register(name)} />
+    </FormControl>
+  );
+};
+
+export default ControlledTextarea;

--- a/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
+++ b/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { UseFormReturn } from 'react-hook-form';
-import {
-  ChakraTextarea,
-  ChakraTextareaProps,
-  FormControl,
-  FormLabel,
-} from '../../chakra';
+import { ChakraTextarea, ChakraTextareaProps, FormLabel } from '../../chakra';
 
 type CustomControlledTextareaProps = {
-  label: string;
-  name: string;
-  localForm: UseFormReturn;
+  label?: string; // optional, displays label if provided
+  name?: string; // optional, not required since no form control
+  tip?: string; // optional, displays tip if provided
+  defaultValue?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
 };
 
 type ControlledTextareaProps = ChakraTextareaProps &
@@ -19,17 +16,22 @@ type ControlledTextareaProps = ChakraTextareaProps &
 const ControlledTextarea: React.FC<ControlledTextareaProps> = ({
   label,
   name,
-  localForm,
+  defaultValue,
+  onChange,
+  value,
   ...props
 }: ControlledTextareaProps) => {
-  const { register } = localForm;
-
   return (
-    <FormControl>
+    <>
       {label && <FormLabel>{label}</FormLabel>}
-      {/* @ts-ignore next-line */}
-      <ChakraTextarea {...props} {...register(name)} />
-    </FormControl>
+      <ChakraTextarea
+        name={name}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        value={value}
+        {...props} // catches other ChakraInput props such as placeholder
+      />
+    </>
   );
 };
 

--- a/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
+++ b/src/components/atoms/ControlledTextarea/ControlledTextarea.tsx
@@ -6,7 +6,7 @@ type CustomControlledTextareaProps = {
   name?: string; // optional, not required since no form control
   tip?: string; // optional, displays tip if provided
   defaultValue?: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   value: string;
 };
 

--- a/src/components/atoms/ControlledTextarea/index.tsx
+++ b/src/components/atoms/ControlledTextarea/index.tsx
@@ -1,0 +1,1 @@
+export { default as ControlledTextarea } from './ControlledTextarea';

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -3,6 +3,7 @@ export * from './Card';
 export * from './Checkbox';
 export * from './ConnectButton';
 export * from './ControlledInput';
+export * from './ControlledTextarea';
 export * from './Heading';
 export * from './Input';
 export * from './List';

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -2,6 +2,7 @@ export * from './Badge';
 export * from './Card';
 export * from './Checkbox';
 export * from './ConnectButton';
+export * from './ControlledInput';
 export * from './Heading';
 export * from './Input';
 export * from './List';

--- a/src/stories/atoms/ControlledInput.stories.tsx
+++ b/src/stories/atoms/ControlledInput.stories.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ControlledInput as InputComponent, Box, Stack } from '../..';
+
+export default {
+  title: 'Components/Atoms/ControlledInput',
+  component: InputComponent,
+} as Meta;
+
+const inputVariants = [
+  { name: 'Outline', variant: 'outline' },
+  { name: 'Flushed', variant: 'flushed' },
+  { name: 'Filled', variant: 'filled' },
+];
+
+const ControlledInput: StoryFn<typeof InputComponent> = () => {
+  const [testValue, setTestValue] = useState<string>(''); // these all share state for the Storybook example
+  const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTestValue(e.target.value);
+  };
+
+  return (
+    <Box m='15px'>
+      <Stack spacing={4}>
+        {inputVariants.map((input) => (
+          <InputComponent
+            label={`ControlledInput - ${input.name} Variant`}
+            variant={input.variant}
+            value={testValue}
+            placeholder='Optional placeholder value' // passes in via the props spread
+            onChange={(e) => handleValueChange(e)}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export { ControlledInput };

--- a/src/stories/atoms/ControlledTextarea.stories.tsx
+++ b/src/stories/atoms/ControlledTextarea.stories.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ControlledTextarea as TextareaComponent, Box, Stack } from '../..';
+
+export default {
+  title: 'Components/Atoms/ControlledTextarea',
+  component: TextareaComponent,
+} as Meta;
+
+const textareaVariants = [
+  { name: 'Outline', variant: 'outline' },
+  { name: 'Flushed', variant: 'flushed' },
+  { name: 'Filled', variant: 'filled' },
+];
+
+const ControlledTextarea: StoryFn<typeof TextareaComponent> = () => {
+  const [testValue, setTestValue] = useState<string>(''); // these all share state for the Storybook example
+  const handleValueChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTestValue(e.target.value);
+  };
+  return (
+    <Box m='15px'>
+      <Stack spacing={4}>
+        {textareaVariants.map((textarea) => (
+          <TextareaComponent
+            label={`ControlledTextarea - ${textarea.name} Variant`}
+            variant={textarea.variant}
+            value={testValue}
+            placeholder='Optional placeholder value' // passes in via the props spread
+            onChange={(e) => handleValueChange(e)}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export { ControlledTextarea };

--- a/src/theme/components/Textarea.ts
+++ b/src/theme/components/Textarea.ts
@@ -3,6 +3,13 @@ const Textarea = {
   variants: {
     filled: {
       borderRadius: '0px',
+      bg: ['gray.700', 'gray.700'],
+      _focus: {
+        bg: ['gray.700', 'gray.700'],
+      },
+      _hover: {
+        bg: ['gray.700', 'gray.700'],
+      },
     },
     outline: {
       border: '1px solid',


### PR DESCRIPTION
## Overview

- Adds controlled versions of Input and Textarea (#57)
- Select will be included in a different PR since we'll be adding react-select (or the wrapped Chakra version)
- Resolves background color issue for Textarea (#55)

## Other Notes

- We'll want to add error messages support to all of our inputs (see comment on #57)
- The `onChange` and `useState` in the stories are for example purposes -- each input shares the state but this is only to demonstrate that the inputs are controlled

