### PR TITLE
feature/add-selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raidguild/design-system",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "license": "MIT",
   "author": "Raid Guild",
   "module": "dist/design-system.esm.js",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@rollup/plugin-replace": "^3.0.0",
     "@storybook/react": "^7.0.0-alpha.43",
     "@storybook/theming": "^7.0.0-alpha.43",
+    "chakra-react-select": "^4.4.3",
     "framer-motion": "^7.6.2",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/src/components/atoms/ControlledCreatableSelect/ControlledCreatableSelect.tsx
+++ b/src/components/atoms/ControlledCreatableSelect/ControlledCreatableSelect.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import {
+  ChakraStylesConfig,
+  CreatableSelect as ReactCreatableSelect,
+} from 'chakra-react-select';
+import { FormLabel, Box, Stack } from '../../chakra';
+
+export type Option =
+  | {
+      label: string | number;
+      value: string | number;
+    }
+  | { value: number | null; label: string }
+  | { value: number; label: string | null | undefined }
+  | { value: null; label: string }
+  | { label: string | number; value: string | number }
+  | { value: number; label: string };
+export interface ControlledCreatableSelectProps {
+  label?: string;
+  placeholder?: string;
+  defaultValue?: Option | Option[];
+  id?: string;
+  options: Option[];
+  isRequired?: boolean;
+  isMulti?: boolean;
+  isClearable?: boolean;
+  onChange?: (option: Option) => void;
+  isDisabled?: boolean;
+  variant?: 'outline' | 'filled' | 'flushed' | undefined;
+  basicStyles?: boolean;
+  value?: any;
+  isSearchable?: boolean;
+
+  colorScheme?:
+    | 'whiteAlpha'
+    | 'blackAlpha'
+    | 'gray'
+    | 'red'
+    | 'orange'
+    | 'yellow'
+    | 'green'
+    | 'teal'
+    | 'blue'
+    | 'cyan'
+    | 'purple'
+    | 'pink'
+    | 'linkedin'
+    | 'facebook'
+    | 'messenger'
+    | 'whatsapp'
+    | 'twitter'
+    | 'telegram'
+    | 'primary';
+}
+
+const ControlledCreatableSelect: React.FC<ControlledCreatableSelectProps> = ({
+  label,
+  placeholder,
+  defaultValue,
+  options,
+  isMulti,
+  isClearable,
+  onChange,
+  isDisabled,
+  value,
+  variant,
+  basicStyles = false,
+  colorScheme = 'primary',
+  isSearchable,
+  ...props
+}: ControlledCreatableSelectProps) => {
+  const chakraStyles: ChakraStylesConfig = {
+    dropdownIndicator: (provided) => ({
+      ...provided,
+      background: 'gray.600',
+      p: 0,
+      w: '40px',
+    }),
+  };
+
+  return (
+    <Stack spacing={2}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <Box my={2}>
+        <ReactCreatableSelect
+          chakraStyles={basicStyles === false ? chakraStyles : {}}
+          options={options}
+          defaultValue={defaultValue}
+          placeholder={placeholder}
+          isClearable={isClearable}
+          isMulti={isMulti}
+          onChange={onChange}
+          isDisabled={isDisabled}
+          variant={variant}
+          colorScheme={colorScheme}
+          value={value}
+          useBasicStyles={basicStyles}
+          isSearchable={isSearchable}
+          {...props}
+        />
+      </Box>
+    </Stack>
+  );
+};
+
+export default ControlledCreatableSelect;

--- a/src/components/atoms/ControlledCreatableSelect/index.tsx
+++ b/src/components/atoms/ControlledCreatableSelect/index.tsx
@@ -1,0 +1,2 @@
+export { default as ControlledCreatableSelect } from './ControlledCreatableSelect';
+export type { ControlledCreatableSelectProps } from './ControlledCreatableSelect';

--- a/src/components/atoms/ControlledSelect/ControlledSelect.tsx
+++ b/src/components/atoms/ControlledSelect/ControlledSelect.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { UseFormReturn, Controller } from 'react-hook-form';
 import { ChakraStylesConfig, Select as ReactSelect } from 'chakra-react-select';
-import { FormLabel, FormControl, Box, Stack } from '../../chakra';
+import { FormLabel, Box, Stack } from '../../chakra';
 
 export type Option =
   | {
@@ -13,23 +12,22 @@ export type Option =
   | { value: null; label: string }
   | { label: string | number; value: string | number }
   | { value: number; label: string };
-export interface SelectProps {
-  name: string;
+export interface ControlledSelectProps {
   label?: string;
   placeholder?: string;
   defaultValue?: Option | Option[];
   id?: string;
   options: Option[];
   isRequired?: boolean;
-  localForm: Pick<UseFormReturn, 'control' | 'formState'>;
   isMulti?: boolean;
   isClearable?: boolean;
-  isSearchable?: boolean;
   onChange?: (option: Option) => void;
   isDisabled?: boolean;
   variant?: 'outline' | 'filled' | 'flushed' | undefined;
   basicStyles?: boolean;
   value?: any;
+  isSearchable?: boolean;
+
   colorScheme?:
     | 'whiteAlpha'
     | 'blackAlpha'
@@ -52,26 +50,22 @@ export interface SelectProps {
     | 'primary';
 }
 
-const Select: React.FC<SelectProps> = ({
+const ControlledSelect: React.FC<ControlledSelectProps> = ({
   label,
-  name,
   placeholder,
   defaultValue,
   options,
   isMulti,
   isClearable,
-  isSearchable,
   onChange,
   isDisabled,
   value,
   variant,
-  localForm,
   basicStyles = false,
   colorScheme = 'primary',
+  isSearchable,
   ...props
-}: SelectProps) => {
-  const { control } = localForm;
-
+}: ControlledSelectProps) => {
   const chakraStyles: ChakraStylesConfig = {
     dropdownIndicator: (provided) => ({
       ...provided,
@@ -82,39 +76,28 @@ const Select: React.FC<SelectProps> = ({
   };
 
   return (
-    <FormControl mb={4}>
-      <Stack spacing={2}>
-        {label && <FormLabel>{label}</FormLabel>}
-        <Box my={2}>
-          <Controller
-            name={name}
-            control={control}
-            shouldUnregister={false}
-            render={({ field }) => (
-              <ReactSelect
-                {...field}
-                chakraStyles={basicStyles === false ? chakraStyles : {}}
-                onBlur={field.onBlur}
-                options={options}
-                defaultValue={defaultValue}
-                placeholder={placeholder}
-                isClearable={isClearable}
-                isMulti={isMulti}
-                onChange={onChange}
-                isDisabled={isDisabled}
-                variant={variant}
-                colorScheme={colorScheme}
-                value={value}
-                useBasicStyles={basicStyles}
-                isSearchable={isSearchable}
-                {...props}
-              />
-            )}
-          />
-        </Box>
-      </Stack>
-    </FormControl>
+    <Stack spacing={2}>
+      {label && <FormLabel>{label}</FormLabel>}
+      <Box my={2}>
+        <ReactSelect
+          chakraStyles={basicStyles === false ? chakraStyles : {}}
+          options={options}
+          defaultValue={defaultValue}
+          placeholder={placeholder}
+          isClearable={isClearable}
+          isMulti={isMulti}
+          onChange={onChange}
+          isDisabled={isDisabled}
+          variant={variant}
+          colorScheme={colorScheme}
+          value={value}
+          useBasicStyles={basicStyles}
+          isSearchable={isSearchable}
+          {...props}
+        />
+      </Box>
+    </Stack>
   );
 };
 
-export default Select;
+export default ControlledSelect;

--- a/src/components/atoms/ControlledSelect/index.tsx
+++ b/src/components/atoms/ControlledSelect/index.tsx
@@ -1,0 +1,2 @@
+export { default as ControlledSelect } from './ControlledSelect';
+export type { ControlledSelectProps } from './ControlledSelect';

--- a/src/components/atoms/CreatableSelect/CreatableSelect.tsx
+++ b/src/components/atoms/CreatableSelect/CreatableSelect.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { UseFormReturn, Controller } from 'react-hook-form';
+import {
+  ChakraStylesConfig,
+  CreatableSelect as ReactCreatableSelect,
+} from 'chakra-react-select';
+import { FormLabel, FormControl, Box, Stack } from '../../chakra';
+
+export type Option =
+  | {
+      label: string | number;
+      value: string | number;
+    }
+  | { value: number | null; label: string }
+  | { value: number; label: string | null | undefined }
+  | { value: null; label: string }
+  | { label: string | number; value: string | number }
+  | { value: number; label: string };
+export interface CreatableSelectProps {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  defaultValue?: Option | Option[];
+  id?: string;
+  options: Option[];
+  isRequired?: boolean;
+  localForm: Pick<UseFormReturn, 'control' | 'formState'>;
+  isMulti?: boolean;
+  isClearable?: boolean;
+  onChange?: (option: Option) => void;
+  isDisabled?: boolean;
+  variant?: 'outline' | 'filled' | 'flushed' | undefined;
+  basicStyles?: boolean;
+  value?: any;
+  colorScheme?:
+    | 'whiteAlpha'
+    | 'blackAlpha'
+    | 'gray'
+    | 'red'
+    | 'orange'
+    | 'yellow'
+    | 'green'
+    | 'teal'
+    | 'blue'
+    | 'cyan'
+    | 'purple'
+    | 'pink'
+    | 'linkedin'
+    | 'facebook'
+    | 'messenger'
+    | 'whatsapp'
+    | 'twitter'
+    | 'telegram'
+    | 'primary';
+}
+
+const CreatableSelect: React.FC<CreatableSelectProps> = ({
+  label,
+  name,
+  placeholder,
+  defaultValue,
+  options,
+  isMulti,
+  isClearable,
+  onChange,
+  isDisabled,
+  value,
+  variant,
+  localForm,
+  basicStyles = false,
+  colorScheme = 'primary',
+  ...props
+}: CreatableSelectProps) => {
+  const { control } = localForm;
+
+  const chakraStyles: ChakraStylesConfig = {
+    dropdownIndicator: (provided) => ({
+      ...provided,
+      background: 'gray.600',
+      p: 0,
+      w: '40px',
+    }),
+  };
+
+  return (
+    <FormControl mb={4}>
+      <Stack spacing={2}>
+        {label && <FormLabel>{label}</FormLabel>}
+        <Box my={2}>
+          <Controller
+            name={name}
+            control={control}
+            shouldUnregister={false}
+            render={({ field }) => (
+              <ReactCreatableSelect
+                {...field}
+                chakraStyles={basicStyles === false ? chakraStyles : {}}
+                onBlur={field.onBlur}
+                options={options}
+                defaultValue={defaultValue}
+                placeholder={placeholder}
+                isClearable={isClearable}
+                isMulti={isMulti}
+                onChange={onChange}
+                isDisabled={isDisabled}
+                variant={variant}
+                colorScheme={colorScheme}
+                value={value}
+                useBasicStyles={basicStyles}
+                {...props}
+              />
+            )}
+          />
+        </Box>
+      </Stack>
+    </FormControl>
+  );
+};
+
+export default CreatableSelect;

--- a/src/components/atoms/CreatableSelect/index.tsx
+++ b/src/components/atoms/CreatableSelect/index.tsx
@@ -1,0 +1,2 @@
+export { default as CreatableSelect } from './CreatableSelect';
+export type { CreatableSelectProps } from './CreatableSelect';

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -68,14 +68,14 @@ const Select: React.FC<SelectProps> = ({
   value,
   variant,
   localForm,
-  basicStyles = true,
+  basicStyles = false,
   colorScheme = 'primary',
   ...props
 }: SelectProps) => {
   const { control } = localForm;
 
   const chakraStyles: ChakraStylesConfig = {
-    dropdownIndicator: (provided, state) => ({
+    dropdownIndicator: (provided) => ({
       ...provided,
       background: 'gray.600',
       p: 0,
@@ -95,7 +95,7 @@ const Select: React.FC<SelectProps> = ({
             render={({ field }) => (
               <ReactSelect
                 {...field}
-                chakraStyles={chakraStyles}
+                chakraStyles={basicStyles === false ? chakraStyles : {}}
                 onBlur={field.onBlur}
                 options={options}
                 defaultValue={defaultValue}

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -1,36 +1,82 @@
 import React from 'react';
-import { UseFormReturn } from 'react-hook-form';
-import { ChakraSelect, ChakraSelectProps } from '../../chakra';
+import { UseFormReturn, Controller } from 'react-hook-form';
+import { Select as ReactSelect } from 'chakra-react-select';
+import { FormLabel, FormControl, Box, Stack } from '../../chakra';
 
-interface SelectOption {
-  label: string;
-  value: any;
-}
-
-interface CustomSelectProps {
+export type Option =
+  | {
+      label: string | number;
+      value: string | number;
+    }
+  | { value: number | null; label: string }
+  | { value: number; label: string | null | undefined }
+  | { value: null; label: string }
+  | { label: string | number; value: string | number }
+  | { value: number; label: string };
+export interface SelectProps {
   name: string;
-  options: SelectOption[];
-  localForm: UseFormReturn;
+  label?: string;
+  placeholder?: string;
+  defaultValue?: Option | Option[];
+  id?: string;
+  options: Option[];
+  isRequired?: boolean;
+  localForm: Pick<UseFormReturn, 'control' | 'formState'>;
+  isMulti?: boolean;
+  isClearable?: boolean;
+  onChange?: (option: Option) => void;
+  isDisabled?: boolean;
+  variant?: 'outline' | 'filled' | 'flushed';
+  value?: any;
 }
-
-export type SelectProps = CustomSelectProps & ChakraSelectProps;
 
 const Select: React.FC<SelectProps> = ({
+  label,
   name,
+  placeholder,
+  defaultValue,
   options,
+  isMulti,
+  isClearable,
+  onChange,
+  isDisabled,
+  value,
+  variant,
   localForm,
-  ...props
 }: SelectProps) => {
-  const { register } = localForm;
+  const {
+    control,
+    formState: { errors },
+  } = localForm;
 
   return (
-    <ChakraSelect {...props} {...register(name)}>
-      {options.map((option) => (
-        <option value={option.value} key={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </ChakraSelect>
+    <FormControl mb={4} isInvalid={errors && errors[name] !== undefined}>
+      <Stack spacing={2}>
+        {label && <FormLabel>{label}</FormLabel>}
+        <Box my={2}>
+          <Controller
+            name={name}
+            control={control}
+            shouldUnregister={false}
+            render={({ field }) => (
+              <ReactSelect
+                {...field}
+                onBlur={field.onBlur}
+                options={options}
+                defaultValue={defaultValue}
+                placeholder={placeholder}
+                isClearable={isClearable}
+                isMulti={isMulti}
+                onChange={onChange}
+                isDisabled={isDisabled}
+                variant={variant}
+                value={value}
+              />
+            )}
+          />
+        </Box>
+      </Stack>
+    </FormControl>
   );
 };
 

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -26,7 +26,7 @@ export interface SelectProps {
   isClearable?: boolean;
   onChange?: (option: Option) => void;
   isDisabled?: boolean;
-  variant?: 'outline' | 'filled' | 'flushed';
+  variant?: 'outline' | 'filled' | 'flushed' | undefined;
   value?: any;
 }
 

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -3,7 +3,7 @@ import { UseFormReturn, Controller } from 'react-hook-form';
 import {
   ChakraStylesConfig,
   Select as ReactSelect,
-  SelectComponent,
+  CreatableSelect as ReactCreatableSelect,
 } from 'chakra-react-select';
 import { FormLabel, FormControl, Box, Stack } from '../../chakra';
 
@@ -21,6 +21,7 @@ export interface SelectProps {
   name: string;
   label?: string;
   placeholder?: string;
+  creatable?: boolean;
   defaultValue?: Option | Option[];
   id?: string;
   options: Option[];
@@ -70,6 +71,7 @@ const Select: React.FC<SelectProps> = ({
   localForm,
   basicStyles = false,
   colorScheme = 'primary',
+  creatable = false,
   ...props
 }: SelectProps) => {
   const { control } = localForm;
@@ -83,39 +85,77 @@ const Select: React.FC<SelectProps> = ({
     }),
   };
 
-  return (
-    <FormControl mb={4}>
-      <Stack spacing={2}>
-        {label && <FormLabel>{label}</FormLabel>}
-        <Box my={2}>
-          <Controller
-            name={name}
-            control={control}
-            shouldUnregister={false}
-            render={({ field }) => (
-              <ReactSelect
-                {...field}
-                chakraStyles={basicStyles === false ? chakraStyles : {}}
-                onBlur={field.onBlur}
-                options={options}
-                defaultValue={defaultValue}
-                placeholder={placeholder}
-                isClearable={isClearable}
-                isMulti={isMulti}
-                onChange={onChange}
-                isDisabled={isDisabled}
-                variant={variant}
-                colorScheme={colorScheme}
-                value={value}
-                useBasicStyles={basicStyles}
-                {...props}
-              />
-            )}
-          />
-        </Box>
-      </Stack>
-    </FormControl>
-  );
+  if (creatable === true) {
+    return (
+      <FormControl mb={4}>
+        <Stack spacing={2}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <Box my={2}>
+            <Controller
+              name={name}
+              control={control}
+              shouldUnregister={false}
+              render={({ field }) => (
+                <ReactCreatableSelect
+                  {...field}
+                  chakraStyles={basicStyles === false ? chakraStyles : {}}
+                  onBlur={field.onBlur}
+                  options={options}
+                  defaultValue={defaultValue}
+                  placeholder={placeholder}
+                  isClearable={isClearable}
+                  isMulti={isMulti}
+                  onChange={onChange}
+                  isDisabled={isDisabled}
+                  variant={variant}
+                  colorScheme={colorScheme}
+                  value={value}
+                  useBasicStyles={basicStyles}
+                  {...props}
+                />
+              )}
+            />
+          </Box>
+        </Stack>
+      </FormControl>
+    );
+  }
+
+  if (creatable === false || creatable === undefined) {
+    return (
+      <FormControl mb={4}>
+        <Stack spacing={2}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <Box my={2}>
+            <Controller
+              name={name}
+              control={control}
+              shouldUnregister={false}
+              render={({ field }) => (
+                <ReactSelect
+                  {...field}
+                  chakraStyles={basicStyles === false ? chakraStyles : {}}
+                  onBlur={field.onBlur}
+                  options={options}
+                  defaultValue={defaultValue}
+                  placeholder={placeholder}
+                  isClearable={isClearable}
+                  isMulti={isMulti}
+                  onChange={onChange}
+                  isDisabled={isDisabled}
+                  variant={variant}
+                  colorScheme={colorScheme}
+                  value={value}
+                  useBasicStyles={basicStyles}
+                  {...props}
+                />
+              )}
+            />
+          </Box>
+        </Stack>
+      </FormControl>
+    );
+  }
 };
 
 export default Select;

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { UseFormReturn, Controller } from 'react-hook-form';
-import { Select as ReactSelect, SelectComponent } from 'chakra-react-select';
+import {
+  ChakraStylesConfig,
+  Select as ReactSelect,
+  SelectComponent,
+} from 'chakra-react-select';
 import { FormLabel, FormControl, Box, Stack } from '../../chakra';
 
 export type Option =
@@ -29,6 +33,26 @@ export interface SelectProps {
   variant?: 'outline' | 'filled' | 'flushed' | undefined;
   basicStyles?: boolean;
   value?: any;
+  colorScheme?:
+    | 'whiteAlpha'
+    | 'blackAlpha'
+    | 'gray'
+    | 'red'
+    | 'orange'
+    | 'yellow'
+    | 'green'
+    | 'teal'
+    | 'blue'
+    | 'cyan'
+    | 'purple'
+    | 'pink'
+    | 'linkedin'
+    | 'facebook'
+    | 'messenger'
+    | 'whatsapp'
+    | 'twitter'
+    | 'telegram'
+    | 'primary';
 }
 
 const Select: React.FC<SelectProps> = ({
@@ -45,9 +69,19 @@ const Select: React.FC<SelectProps> = ({
   variant,
   localForm,
   basicStyles = true,
+  colorScheme = 'primary',
   ...props
 }: SelectProps) => {
   const { control } = localForm;
+
+  const chakraStyles: ChakraStylesConfig = {
+    dropdownIndicator: (provided, state) => ({
+      ...provided,
+      background: 'gray.600',
+      p: 0,
+      w: '40px',
+    }),
+  };
 
   return (
     <FormControl mb={4}>
@@ -61,6 +95,7 @@ const Select: React.FC<SelectProps> = ({
             render={({ field }) => (
               <ReactSelect
                 {...field}
+                chakraStyles={chakraStyles}
                 onBlur={field.onBlur}
                 options={options}
                 defaultValue={defaultValue}
@@ -70,9 +105,9 @@ const Select: React.FC<SelectProps> = ({
                 onChange={onChange}
                 isDisabled={isDisabled}
                 variant={variant}
-                colorScheme='primary'
-                useBasicStyles={basicStyles}
+                colorScheme={colorScheme}
                 value={value}
+                useBasicStyles={basicStyles}
                 {...props}
               />
             )}

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { UseFormReturn, Controller } from 'react-hook-form';
-import { Select as ReactSelect } from 'chakra-react-select';
+import { Select as ReactSelect, SelectComponent } from 'chakra-react-select';
 import { FormLabel, FormControl, Box, Stack } from '../../chakra';
 
 export type Option =
@@ -27,6 +27,7 @@ export interface SelectProps {
   onChange?: (option: Option) => void;
   isDisabled?: boolean;
   variant?: 'outline' | 'filled' | 'flushed' | undefined;
+  basicStyles?: boolean;
   value?: any;
 }
 
@@ -43,14 +44,13 @@ const Select: React.FC<SelectProps> = ({
   value,
   variant,
   localForm,
+  basicStyles = true,
+  ...props
 }: SelectProps) => {
-  const {
-    control,
-    formState: { errors },
-  } = localForm;
+  const { control } = localForm;
 
   return (
-    <FormControl mb={4} isInvalid={errors && errors[name] !== undefined}>
+    <FormControl mb={4}>
       <Stack spacing={2}>
         {label && <FormLabel>{label}</FormLabel>}
         <Box my={2}>
@@ -70,7 +70,10 @@ const Select: React.FC<SelectProps> = ({
                 onChange={onChange}
                 isDisabled={isDisabled}
                 variant={variant}
+                colorScheme='primary'
+                useBasicStyles={basicStyles}
                 value={value}
+                {...props}
               />
             )}
           />

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { UseFormReturn, Controller } from 'react-hook-form';
-import {
-  ChakraStylesConfig,
-  Select as ReactSelect,
-  CreatableSelect as ReactCreatableSelect,
-} from 'chakra-react-select';
+import { ChakraStylesConfig, Select as ReactSelect } from 'chakra-react-select';
 import { FormLabel, FormControl, Box, Stack } from '../../chakra';
 
 export type Option =
@@ -21,7 +17,6 @@ export interface SelectProps {
   name: string;
   label?: string;
   placeholder?: string;
-  creatable?: boolean;
   defaultValue?: Option | Option[];
   id?: string;
   options: Option[];
@@ -71,7 +66,6 @@ const Select: React.FC<SelectProps> = ({
   localForm,
   basicStyles = false,
   colorScheme = 'primary',
-  creatable = false,
   ...props
 }: SelectProps) => {
   const { control } = localForm;
@@ -85,77 +79,39 @@ const Select: React.FC<SelectProps> = ({
     }),
   };
 
-  if (creatable === true) {
-    return (
-      <FormControl mb={4}>
-        <Stack spacing={2}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <Box my={2}>
-            <Controller
-              name={name}
-              control={control}
-              shouldUnregister={false}
-              render={({ field }) => (
-                <ReactCreatableSelect
-                  {...field}
-                  chakraStyles={basicStyles === false ? chakraStyles : {}}
-                  onBlur={field.onBlur}
-                  options={options}
-                  defaultValue={defaultValue}
-                  placeholder={placeholder}
-                  isClearable={isClearable}
-                  isMulti={isMulti}
-                  onChange={onChange}
-                  isDisabled={isDisabled}
-                  variant={variant}
-                  colorScheme={colorScheme}
-                  value={value}
-                  useBasicStyles={basicStyles}
-                  {...props}
-                />
-              )}
-            />
-          </Box>
-        </Stack>
-      </FormControl>
-    );
-  }
-
-  if (creatable === false || creatable === undefined) {
-    return (
-      <FormControl mb={4}>
-        <Stack spacing={2}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <Box my={2}>
-            <Controller
-              name={name}
-              control={control}
-              shouldUnregister={false}
-              render={({ field }) => (
-                <ReactSelect
-                  {...field}
-                  chakraStyles={basicStyles === false ? chakraStyles : {}}
-                  onBlur={field.onBlur}
-                  options={options}
-                  defaultValue={defaultValue}
-                  placeholder={placeholder}
-                  isClearable={isClearable}
-                  isMulti={isMulti}
-                  onChange={onChange}
-                  isDisabled={isDisabled}
-                  variant={variant}
-                  colorScheme={colorScheme}
-                  value={value}
-                  useBasicStyles={basicStyles}
-                  {...props}
-                />
-              )}
-            />
-          </Box>
-        </Stack>
-      </FormControl>
-    );
-  }
+  return (
+    <FormControl mb={4}>
+      <Stack spacing={2}>
+        {label && <FormLabel>{label}</FormLabel>}
+        <Box my={2}>
+          <Controller
+            name={name}
+            control={control}
+            shouldUnregister={false}
+            render={({ field }) => (
+              <ReactSelect
+                {...field}
+                chakraStyles={basicStyles === false ? chakraStyles : {}}
+                onBlur={field.onBlur}
+                options={options}
+                defaultValue={defaultValue}
+                placeholder={placeholder}
+                isClearable={isClearable}
+                isMulti={isMulti}
+                onChange={onChange}
+                isDisabled={isDisabled}
+                variant={variant}
+                colorScheme={colorScheme}
+                value={value}
+                useBasicStyles={basicStyles}
+                {...props}
+              />
+            )}
+          />
+        </Box>
+      </Stack>
+    </FormControl>
+  );
 };
 
 export default Select;

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -3,6 +3,7 @@ export * from './Card';
 export * from './Checkbox';
 export * from './ControlledInput';
 export * from './ControlledTextarea';
+export * from './CreatableSelect';
 export * from './Heading';
 export * from './Input';
 export * from './List';

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -4,6 +4,7 @@ export * from './Checkbox';
 export * from './ControlledInput';
 export * from './ControlledTextarea';
 export * from './ControlledSelect';
+export * from './ControlledCreatableSelect';
 export * from './CreatableSelect';
 export * from './Heading';
 export * from './Input';

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -3,6 +3,7 @@ export * from './Card';
 export * from './Checkbox';
 export * from './ControlledInput';
 export * from './ControlledTextarea';
+export * from './ControlledSelect';
 export * from './CreatableSelect';
 export * from './Heading';
 export * from './Input';

--- a/src/stories/atoms/ControlledCreatableSelect.stories.tsx
+++ b/src/stories/atoms/ControlledCreatableSelect.stories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { Meta, StoryFn } from '@storybook/react';
+import { CreatableSelect as SelectComponent, Box, Stack, Text } from '../..';
+
+export default {
+  title: 'Components/Atoms/ControlledCreatableSelect',
+  component: SelectComponent,
+} as Meta<typeof SelectComponent>;
+
+type SelectVariant = {
+  name: string;
+  variant: 'outline' | 'filled' | 'flushed';
+  isMulti?: boolean;
+  creatable?: boolean;
+  basicStyles?: boolean;
+};
+
+const selectVariants: SelectVariant[] = [
+  { name: 'Single Outline', variant: 'outline', isMulti: false },
+  { name: 'Single Filled', variant: 'filled', isMulti: false },
+  { name: 'Single Flushed', variant: 'flushed', isMulti: false },
+  {
+    name: 'Single Outline Basic',
+    variant: 'outline',
+    isMulti: false,
+    basicStyles: true,
+  },
+
+  { name: 'Multi Outline', variant: 'outline', isMulti: true },
+  { name: 'Multi Filled', variant: 'filled', isMulti: true },
+  { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
+  {
+    name: 'Multi Outline Basic',
+    variant: 'outline',
+    isMulti: true,
+    basicStyles: true,
+  },
+];
+
+const selectOptions = [
+  { label: '$1000', value: 1000 },
+  { label: '$10,000', value: 10000 },
+];
+
+const multiSelectOptions = [
+  { label: 'Frontend Dev', value: 'Frontend Dev' },
+  { label: 'Backend Dev', value: 'Backend Dev' },
+  { label: 'Design', value: 'Design' },
+  { label: 'Smart Contracts', value: 'Smart Contracts' },
+];
+
+const ControlledCreatableSelect: StoryFn<typeof SelectComponent> = () => {
+  const localForm = useForm();
+  return (
+    <Box w='50%'>
+      <Stack spacing={5}>
+        {selectVariants.map((select) => (
+          <Stack spacing={3}>
+            <Text>{select.name}</Text>
+            <SelectComponent
+              name='testSelect'
+              options={
+                select.isMulti === true ? multiSelectOptions : selectOptions
+              }
+              variant={select.variant}
+              localForm={localForm}
+              isMulti={select.isMulti}
+              basicStyles={select.basicStyles}
+            />
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export { ControlledCreatableSelect };

--- a/src/stories/atoms/ControlledSelect.stories.tsx
+++ b/src/stories/atoms/ControlledSelect.stories.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ControlledSelect as SelectComponent, Box, Stack, Text } from '../..';
+
+export default {
+  title: 'Components/Atoms/ControlledSelect',
+  component: SelectComponent,
+} as Meta<typeof SelectComponent>;
+
+type SelectVariant = {
+  name: string;
+  variant: 'outline' | 'filled' | 'flushed';
+  isMulti?: boolean;
+  creatable?: boolean;
+  basicStyles?: boolean;
+};
+
+type Option =
+  | {
+      label: string | number;
+      value: string | number;
+    }
+  | { value: number | null; label: string }
+  | { value: number; label: string | null | undefined }
+  | { value: null; label: string }
+  | { label: string | number; value: string | number }
+  | { value: number; label: string };
+
+const selectVariants: SelectVariant[] = [
+  { name: 'Single Outline', variant: 'outline', isMulti: false },
+  { name: 'Single Filled', variant: 'filled', isMulti: false },
+  { name: 'Single Flushed', variant: 'flushed', isMulti: false },
+  {
+    name: 'Single Outline Basic',
+    variant: 'outline',
+    isMulti: false,
+    basicStyles: true,
+  },
+
+  { name: 'Multi Outline', variant: 'outline', isMulti: true },
+  { name: 'Multi Filled', variant: 'filled', isMulti: true },
+  { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
+  {
+    name: 'Multi Outline Basic',
+    variant: 'outline',
+    isMulti: true,
+    basicStyles: true,
+  },
+];
+
+const selectOptions = [
+  { label: '$1000', value: 1000 },
+  { label: '$10,000', value: 10000 },
+];
+
+const multiSelectOptions = [
+  { label: 'Frontend Dev', value: 'Frontend Dev' },
+  { label: 'Backend Dev', value: 'Backend Dev' },
+  { label: 'Design', value: 'Design' },
+  { label: 'Smart Contracts', value: 'Smart Contracts' },
+];
+
+const ControlledSelect: StoryFn<typeof SelectComponent> = () => {
+  const [, setSelectedValue] = useState<Option>();
+  // these all share state for the Storybook example
+  // set your own state via the ControlledSelect's onChange
+
+  return (
+    <Box w='50%'>
+      <Stack spacing={5}>
+        {selectVariants.map((select) => (
+          <Stack spacing={3}>
+            <Text>{select.name}</Text>
+            <SelectComponent
+              options={
+                select.isMulti === true ? multiSelectOptions : selectOptions
+              }
+              variant={select.variant}
+              isMulti={select.isMulti}
+              basicStyles={select.basicStyles}
+              onChange={(selection: Option) => setSelectedValue(selection)}
+            />
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export { ControlledSelect };

--- a/src/stories/atoms/CreatableSelect.stories.tsx
+++ b/src/stories/atoms/CreatableSelect.stories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { Meta, StoryFn } from '@storybook/react';
+import { CreatableSelect as SelectComponent, Box, Stack, Text } from '../..';
+
+export default {
+  title: 'Components/Atoms/CreatableSelect',
+  component: SelectComponent,
+} as Meta<typeof SelectComponent>;
+
+type SelectVariant = {
+  name: string;
+  variant: 'outline' | 'filled' | 'flushed';
+  isMulti?: boolean;
+  creatable?: boolean;
+  basicStyles?: boolean;
+};
+
+const selectVariants: SelectVariant[] = [
+  { name: 'Single Outline', variant: 'outline', isMulti: false },
+  { name: 'Single Filled', variant: 'filled', isMulti: false },
+  { name: 'Single Flushed', variant: 'flushed', isMulti: false },
+  {
+    name: 'Single Outline Basic',
+    variant: 'outline',
+    isMulti: false,
+    basicStyles: true,
+  },
+
+  { name: 'Multi Outline', variant: 'outline', isMulti: true },
+  { name: 'Multi Filled', variant: 'filled', isMulti: true },
+  { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
+  {
+    name: 'Multi Outline Basic',
+    variant: 'outline',
+    isMulti: true,
+    basicStyles: true,
+  },
+];
+
+const selectOptions = [
+  { label: '$1000', value: 1000 },
+  { label: '$10,000', value: 10000 },
+];
+
+const multiSelectOptions = [
+  { label: 'Frontend Dev', value: 'Frontend Dev' },
+  { label: 'Backend Dev', value: 'Backend Dev' },
+  { label: 'Design', value: 'Design' },
+  { label: 'Smart Contracts', value: 'Smart Contracts' },
+];
+
+const CreatableSelect: StoryFn<typeof SelectComponent> = () => {
+  const localForm = useForm();
+  return (
+    <Box w='50%'>
+      <Stack spacing={5}>
+        {selectVariants.map((select) => (
+          <Stack spacing={3}>
+            <Text>{select.name}</Text>
+            <SelectComponent
+              name='testSelect'
+              options={
+                select.isMulti === true ? multiSelectOptions : selectOptions
+              }
+              variant={select.variant}
+              localForm={localForm}
+              isMulti={select.isMulti}
+              basicStyles={select.basicStyles}
+            />
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export { CreatableSelect };

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -8,7 +8,13 @@ export default {
   component: SelectComponent,
 } as Meta<typeof SelectComponent>;
 
-const selectVariants = [
+type SelectVariant = {
+  name: string;
+  variant: 'outline' | 'filled' | 'flushed';
+  isMulti?: boolean;
+};
+
+const selectVariants: SelectVariant[] = [
   { name: 'Single Outline', variant: 'outline' },
   { name: 'Single Filled', variant: 'filled' },
   { name: 'Single Flushed', variant: 'flushed' },

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -26,12 +26,7 @@ const selectVariants: SelectVariant[] = [
     isMulti: false,
     basicStyles: true,
   },
-  {
-    name: 'Single Outline Creatable',
-    variant: 'outline',
-    isMulti: false,
-    creatable: true,
-  },
+
   { name: 'Multi Outline', variant: 'outline', isMulti: true },
   { name: 'Multi Filled', variant: 'filled', isMulti: true },
   { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
@@ -40,12 +35,6 @@ const selectVariants: SelectVariant[] = [
     variant: 'outline',
     isMulti: true,
     basicStyles: true,
-  },
-  {
-    name: 'Multi Outline Creatable',
-    variant: 'outline',
-    isMulti: true,
-    creatable: true,
   },
 ];
 

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -12,6 +12,7 @@ type SelectVariant = {
   name: string;
   variant: 'outline' | 'filled' | 'flushed';
   isMulti?: boolean;
+  creatable?: boolean;
   basicStyles?: boolean;
 };
 
@@ -25,6 +26,12 @@ const selectVariants: SelectVariant[] = [
     isMulti: false,
     basicStyles: true,
   },
+  {
+    name: 'Single Outline Creatable',
+    variant: 'outline',
+    isMulti: false,
+    creatable: true,
+  },
   { name: 'Multi Outline', variant: 'outline', isMulti: true },
   { name: 'Multi Filled', variant: 'filled', isMulti: true },
   { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
@@ -33,6 +40,12 @@ const selectVariants: SelectVariant[] = [
     variant: 'outline',
     isMulti: true,
     basicStyles: true,
+  },
+  {
+    name: 'Multi Outline Creatable',
+    variant: 'outline',
+    isMulti: true,
+    creatable: true,
   },
 ];
 

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -15,9 +15,9 @@ type SelectVariant = {
 };
 
 const selectVariants: SelectVariant[] = [
-  { name: 'Single Outline', variant: 'outline' },
-  { name: 'Single Filled', variant: 'filled' },
-  { name: 'Single Flushed', variant: 'flushed' },
+  { name: 'Single Outline', variant: 'outline', isMulti: false },
+  { name: 'Single Filled', variant: 'filled', isMulti: false },
+  { name: 'Single Flushed', variant: 'flushed', isMulti: false },
   { name: 'Multi Outline', variant: 'outline', isMulti: true },
   { name: 'Multi Filled', variant: 'filled', isMulti: true },
   { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
@@ -51,7 +51,7 @@ const Select: StoryFn<typeof SelectComponent> = () => {
               variant={select.variant}
               localForm={localForm}
               isMulti={select.isMulti}
-              basicStyles
+              basicStyles={false}
             />
           </Stack>
         ))}

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -12,15 +12,28 @@ type SelectVariant = {
   name: string;
   variant: 'outline' | 'filled' | 'flushed';
   isMulti?: boolean;
+  basicStyles?: boolean;
 };
 
 const selectVariants: SelectVariant[] = [
   { name: 'Single Outline', variant: 'outline', isMulti: false },
   { name: 'Single Filled', variant: 'filled', isMulti: false },
   { name: 'Single Flushed', variant: 'flushed', isMulti: false },
+  {
+    name: 'Single Outline Basic',
+    variant: 'outline',
+    isMulti: false,
+    basicStyles: true,
+  },
   { name: 'Multi Outline', variant: 'outline', isMulti: true },
   { name: 'Multi Filled', variant: 'filled', isMulti: true },
   { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
+  {
+    name: 'Multi Outline Basic',
+    variant: 'outline',
+    isMulti: true,
+    basicStyles: true,
+  },
 ];
 
 const selectOptions = [
@@ -51,7 +64,7 @@ const Select: StoryFn<typeof SelectComponent> = () => {
               variant={select.variant}
               localForm={localForm}
               isMulti={select.isMulti}
-              basicStyles={false}
+              basicStyles={select.basicStyles}
             />
           </Stack>
         ))}

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -28,6 +28,13 @@ const selectOptions = [
   { label: '$10,000', value: 10000 },
 ];
 
+const multiSelectOptions = [
+  { label: 'Frontend Dev', value: 'Frontend Dev' },
+  { label: 'Backend Dev', value: 'Backend Dev' },
+  { label: 'Design', value: 'Design' },
+  { label: 'Smart Contracts', value: 'Smart Contracts' },
+];
+
 const Select: StoryFn<typeof SelectComponent> = () => {
   const localForm = useForm();
   return (
@@ -37,11 +44,14 @@ const Select: StoryFn<typeof SelectComponent> = () => {
           <Stack spacing={3}>
             <Text>{select.name}</Text>
             <SelectComponent
-              name='testing'
-              options={selectOptions}
+              name='testSelect'
+              options={
+                select.isMulti === true ? multiSelectOptions : selectOptions
+              }
               variant={select.variant}
               localForm={localForm}
               isMulti={select.isMulti}
+              basicStyles
             />
           </Stack>
         ))}

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -9,9 +9,12 @@ export default {
 } as Meta<typeof SelectComponent>;
 
 const selectVariants = [
-  { name: 'Outline', variant: 'outline' },
-  { name: 'Filled', variant: 'filled' },
-  { name: 'Flushed', variant: 'flushed' },
+  { name: 'Single Outline', variant: 'outline' },
+  { name: 'Single Filled', variant: 'filled' },
+  { name: 'Single Flushed', variant: 'flushed' },
+  { name: 'Multi Outline', variant: 'outline', isMulti: true },
+  { name: 'Multi Filled', variant: 'filled', isMulti: true },
+  { name: 'Multi Flushed', variant: 'flushed', isMulti: true },
 ];
 
 const selectOptions = [
@@ -32,6 +35,7 @@ const Select: StoryFn<typeof SelectComponent> = () => {
               options={selectOptions}
               variant={select.variant}
               localForm={localForm}
+              isMulti={select.isMulti}
             />
           </Stack>
         ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,13 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -1911,7 +1918,7 @@
     source-map "^0.5.7"
     stylis "4.1.3"
 
-"@emotion/cache@^11.10.5":
+"@emotion/cache@^11.10.5", "@emotion/cache@^11.4.0":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
   integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
@@ -1951,7 +1958,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.10.5":
+"@emotion/react@^11.10.5", "@emotion/react@^11.8.1":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
@@ -2037,6 +2044,18 @@
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
+
+"@floating-ui/core@^1.0.5":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.0.tgz#0a1dee4bbce87ff71602625d33f711cafd8afc08"
+  integrity sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==
+
+"@floating-ui/dom@^1.0.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.0.tgz#29fea1344fdef15b6ba270a733d20b7134fee5c2"
+  integrity sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==
+  dependencies:
+    "@floating-ui/core" "^1.0.5"
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"
@@ -3873,6 +3892,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@>=16", "@types/react@^18.0.0":
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
@@ -5500,6 +5526,13 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+chakra-react-select@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/chakra-react-select/-/chakra-react-select-4.4.3.tgz#678fcb25b90b9f977628694d1a9d49d072e01128"
+  integrity sha512-anDgJyYUpIapTmUbgXB+Iw5hJ90hOPvgoUPUaYdO5q9zY2VBFhQ1L0gBMqWAQxiKUmuHpwQypf8sPoVtd0b3KA==
+  dependencies:
+    react-select "5.7.0"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -6548,6 +6581,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -10566,6 +10607,11 @@ memfs@^3.4.1, memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.3"
 
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -12242,7 +12288,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12590,6 +12636,21 @@ react-remove-scroll@^2.5.4:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-select@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.0.tgz#82921b38f1fcf1471a0b62304da01f2896cd8ce6"
+  integrity sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
@@ -12598,6 +12659,16 @@ react-style-singleton@^2.2.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"
@@ -12711,6 +12782,11 @@ regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.7:
   version "0.13.10"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
   integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-transform@^0.15.0:
   version "0.15.0"
@@ -14784,6 +14860,11 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
+
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Overview

This closes #60. This adds the following:

- React Select via `chakra-react-select`
- Controlled Select, Select, CreatableSelect, CreatableControlledSelect

Each of these uses the theme and Chakra style. I didn't add too much to the default, but it uses the `primary` Raid Guild color for this with the option to pass in any of the supported Chakra `colorScheme`

There is an option to use `basicStyles` (prop name) that renders the Select without the visually separated dropdown button.